### PR TITLE
Change "descrete" -> "discrete".

### DIFF
--- a/chapterProbability.tex
+++ b/chapterProbability.tex
@@ -16,7 +16,7 @@ One big advantage of the Bayesian interpretation is that it can be used to model
 \subsection{Basic concepts}
 We denote a random event by defining a \textbf{random variable} $X$.
 
-\textbf{Descrete random variable}: $X$ can take on any value from a finite or countably infinite set.
+\textbf{Discrete random variable}: $X$ can take on any value from a finite or countably infinite set.
 
 \textbf{Continuous random variable}: the value of $X$ is real-valued.
 
@@ -32,7 +32,7 @@ F(x) \triangleq P(X \leq x)=\begin{cases}
 
 
 \subsubsection{PMF and PDF}
-For descrete random variable, We denote the probability of the event that $X=x$ by $P(X=x)$, or just $p(x)$ for short. Here $p(x)$ is called a \textbf{probability mass function} or \textbf{PMF}.A probability mass function is a function that gives the probability that a discrete random variable is exactly equal to some value\footnote{\url{http://en.wikipedia.org/wiki/Probability_mass_function}}. This satisfies the properties $0 \leq p(x) \leq 1$ and $\sum_{x \in \mathcal{X}} p(x)=1$.
+For discrete random variable, We denote the probability of the event that $X=x$ by $P(X=x)$, or just $p(x)$ for short. Here $p(x)$ is called a \textbf{probability mass function} or \textbf{PMF}.A probability mass function is a function that gives the probability that a discrete random variable is exactly equal to some value\footnote{\url{http://en.wikipedia.org/wiki/Probability_mass_function}}. This satisfies the properties $0 \leq p(x) \leq 1$ and $\sum_{x \in \mathcal{X}} p(x)=1$.
 
 For continuous variable, in the equation $F(x)=\int_{-\infty}^{x} f(u)\mathrm{d}u$, the function $f(x)$ is called a \textbf{probability density function} or \textbf{PDF}. A probability density function is a function that describes the relative likelihood for this random variable to take on a given value\footnote{\url{http://en.wikipedia.org/wiki/Probability_density_function}}.This satisfies the properties $f(x) \geq 0$ and $\int_{-\infty}^{\infty} f(x)\mathrm{d}x=1$.
 
@@ -81,12 +81,12 @@ p(X_{1:N})=p(X_1)p(X_2|X_1)p(X_3|X_2,X_1)...p(X_N|X_{1:N-1})
 
 \textbf{Marginal PMF and PDF}:
 \begin{equation} \begin{cases}
-P(X=x_i)=\sum_{j=1}^{+\infty}P(X=x_i,Y=y_j) & \text{, descrete}\\
+P(X=x_i)=\sum_{j=1}^{+\infty}P(X=x_i,Y=y_j) & \text{, discrete}\\
 f_X(x)=\int_{-\infty}^{+\infty} f(x,y)\mathrm{d}y & \text{, continuous}\\
 \end{cases}\end{equation}
 
 \begin{equation}\begin{cases}
-p(Y=y_j)=\sum_{i=1}^{+\infty}P(X=x_i,Y=y_j) & \text{, descrete}\\
+p(Y=y_j)=\sum_{i=1}^{+\infty}P(X=x_i,Y=y_j) & \text{, discrete}\\
 f_Y(y)=\int_{-\infty}^{+\infty} f(x,y)\mathrm{d}x & \text{, continuous}\\
 \end{cases}\end{equation}
 


### PR DESCRIPTION
Discrete is the proper term for non-continous functions/random variables.

I've `grep`'ed the entire document, and these 4 lines seem to be the only occurrences of `descrete`.